### PR TITLE
Use linktree model for external links

### DIFF
--- a/app/Models/Linktree.php
+++ b/app/Models/Linktree.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+
+class Linktree extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+        'url',
+        'category',
+    ];
+
+    /**
+     * Retrieve all links keyed by slug from cache.
+     */
+    public static function getCachedLinks(): Collection
+    {
+        if (! Schema::hasTable((new static())->getTable())) {
+            return collect();
+        }
+
+        return Cache::rememberForever('linktree.links', function () {
+            return static::query()->orderBy('slug')->get()->keyBy('slug');
+        });
+    }
+
+    /**
+     * Resolve the URL for a given link slug.
+     */
+    public static function url(string $slug, ?string $default = null): ?string
+    {
+        $link = static::getCachedLinks()->get($slug);
+
+        return $link?->url ?? $default;
+    }
+
+    /**
+     * Flush cached link data when the model changes.
+     */
+    protected static function booted(): void
+    {
+        $flush = fn () => Cache::forget('linktree.links');
+
+        static::saved($flush);
+        static::deleted($flush);
+    }
+}

--- a/database/migrations/2025_09_09_160000_create_linktrees_table.php
+++ b/database/migrations/2025_09_09_160000_create_linktrees_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('linktrees', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('url');
+            $table->string('category')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('linktrees');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,5 +15,7 @@ class DatabaseSeeder extends Seeder
         Artist::create([
             'spotify_id' => '1YhRX1mRz6rzQofSyzlszi',
         ]);
+
+        $this->call(LinktreeSeeder::class);
     }
 }

--- a/database/seeders/LinktreeSeeder.php
+++ b/database/seeders/LinktreeSeeder.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Linktree;
+use Illuminate\Database\Seeder;
+
+class LinktreeSeeder extends Seeder
+{
+    /**
+     * Seed the application's linktree links.
+     */
+    public function run(): void
+    {
+        $links = [
+            [
+                'name' => 'Spotify',
+                'slug' => 'spotify',
+                'url' => 'https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi',
+                'category' => 'music',
+            ],
+            [
+                'name' => 'Instagram',
+                'slug' => 'instagram',
+                'url' => 'https://www.instagram.com/pointofmadnessband/',
+                'category' => 'social',
+            ],
+            [
+                'name' => 'TikTok',
+                'slug' => 'tiktok',
+                'url' => 'https://www.tiktok.com/@point.of.madness',
+                'category' => 'social',
+            ],
+            [
+                'name' => 'Amazon Music',
+                'slug' => 'amazon_music',
+                'url' => 'https://music.amazon.com/artists/B0CZV1WG82/point-of-madness',
+                'category' => 'music',
+            ],
+            [
+                'name' => 'Deezer',
+                'slug' => 'deezer',
+                'url' => 'https://www.deezer.com/us/artist/260843331',
+                'category' => 'music',
+            ],
+            [
+                'name' => 'Tidal',
+                'slug' => 'tidal',
+                'url' => 'https://tidal.com/artist/46872152',
+                'category' => 'music',
+            ],
+            [
+                'name' => 'Qobuz',
+                'slug' => 'qobuz',
+                'url' => 'https://open.qobuz.com/artist/22007984',
+                'category' => 'music',
+            ],
+            [
+                'name' => 'YouTube',
+                'slug' => 'youtube',
+                'url' => 'https://www.youtube.com/@PointofMadness',
+                'category' => 'video',
+            ],
+            [
+                'name' => 'YouTube Music',
+                'slug' => 'youtube_music',
+                'url' => 'https://music.youtube.com/channel/UC3byFEMycsebbNGxeFhx6CQ',
+                'category' => 'music',
+            ],
+            [
+                'name' => 'TOXIC - Music Video',
+                'slug' => 'toxic_music_video',
+                'url' => 'https://www.youtube.com/watch?v=HGcrZPMlOrw',
+                'category' => 'video',
+            ],
+        ];
+
+        foreach ($links as $link) {
+            Linktree::updateOrCreate(
+                ['slug' => $link['slug']],
+                $link,
+            );
+        }
+    }
+}

--- a/resources/views/components/home/hero.blade.php
+++ b/resources/views/components/home/hero.blade.php
@@ -94,8 +94,8 @@
 
     <!-- Professional Action Buttons -->
     <div class="relative z-10 flex flex-col sm:flex-row gap-4 items-center justify-center mb-8">
-        <button
-            class="group relative px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600
+        <a href="{{ \App\Models\Linktree::url('spotify', '#') }}" target="_blank"
+           class="group relative px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600
                       text-white font-semibold rounded-full hover:from-blue-500 hover:to-purple-500
                       transition-all duration-300 transform hover:scale-105 hover:shadow-xl
                       hover:shadow-blue-500/30 flex items-center gap-3">
@@ -103,7 +103,7 @@
                 <path d="M8 5v14l11-7z" />
             </svg>
             Listen Now
-        </button>
+        </a>
 
         <x-modal.linktree.button />
     </div>

--- a/resources/views/components/home/music.blade.php
+++ b/resources/views/components/home/music.blade.php
@@ -129,7 +129,7 @@
                     <div class="text-white font-semibold">{{ is_numeric($artist?->spotify_monthly_listeners ?? $artist?->monthly_listeners) ? number_format((float) ($artist?->spotify_monthly_listeners ?? $artist?->monthly_listeners)) : 'N/A' }} monthly listeners</div>
                     <div class="text-gray-400 text-sm">Follow us on Spotify for new releases</div>
                 </div>
-                <a href="https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi" target="_blank"
+                <a href="{{ \App\Models\Linktree::url('spotify', '#') }}" target="_blank"
                    class="bg-green-500 hover:bg-green-400 text-white px-4 py-2 rounded-full text-sm font-semibold
                           transition-all duration-300 transform hover:scale-105">
                     Follow

--- a/resources/views/components/layouts/footer.blade.php
+++ b/resources/views/components/layouts/footer.blade.php
@@ -1,4 +1,7 @@
 @use('Carbon\Carbon')
+@php
+    $spotifyLink = \App\Models\Linktree::url('spotify', '#');
+@endphp
 
 <!-- Professional Footer -->
 <footer class="relative mt-24 py-16 px-6">
@@ -29,14 +32,14 @@
                 <div>
                     <h4 class="text-white font-semibold mb-4 text-lg">Listen</h4>
                     <div class="space-y-2">
-                        <a href="https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi" target="_blank"
+                        <a href="{{ $spotifyLink }}" target="_blank"
                            class="block text-gray-400 hover:text-green-400 transition-colors duration-300">
                             Spotify
                         </a>
-                        <a href="#" class="block text-gray-400 hover:text-red-400 transition-colors duration-300">
+                        <a href="{{ \App\Models\Linktree::url('youtube', $spotifyLink) }}" target="_blank" class="block text-gray-400 hover:text-red-400 transition-colors duration-300">
                             YouTube
                         </a>
-                        <a href="#" class="block text-gray-400 hover:text-orange-400 transition-colors duration-300">
+                        <a href="{{ \App\Models\Linktree::url('apple_music', $spotifyLink) }}" target="_blank" class="block text-gray-400 hover:text-orange-400 transition-colors duration-300">
                             Apple Music
                         </a>
                     </div>
@@ -46,18 +49,18 @@
                 <div>
                     <h4 class="text-white font-semibold mb-4 text-lg">Connect</h4>
                     <div class="space-y-2">
-                        <a href="https://www.instagram.com/pointofmadnessband/" target="_blank"
+                        <a href="{{ \App\Models\Linktree::url('instagram', $spotifyLink) }}" target="_blank"
                            class="block text-gray-400 hover:text-pink-400 transition-colors duration-300">
                             Instagram
                         </a>
-                        <a href="https://www.tiktok.com/@point.of.madness" target="_blank"
+                        <a href="{{ \App\Models\Linktree::url('tiktok', $spotifyLink) }}" target="_blank"
                            class="block text-gray-400 hover:text-pink-400 transition-colors duration-300">
                             TikTok
                         </a>
-                        <a href="#" class="block text-gray-400 hover:text-blue-400 transition-colors duration-300">
+                        <a href="{{ \App\Models\Linktree::url('facebook', $spotifyLink) }}" target="_blank" class="block text-gray-400 hover:text-blue-400 transition-colors duration-300">
                             Facebook
                         </a>
-                        <a href="#" class="block text-gray-400 hover:text-cyan-400 transition-colors duration-300">
+                        <a href="{{ \App\Models\Linktree::url('twitter', $spotifyLink) }}" target="_blank" class="block text-gray-400 hover:text-cyan-400 transition-colors duration-300">
                             Twitter
                         </a>
                     </div>
@@ -82,7 +85,7 @@
             
             <!-- Social Icons -->
             <div class="flex justify-center space-x-6 mb-8">
-                <a href="https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi" target="_blank"
+                <a href="{{ $spotifyLink }}" target="_blank"
                    class="group w-12 h-12 bg-gradient-to-br from-green-500/20 to-green-600/20 
                           border border-green-500/30 rounded-full flex items-center justify-center 
                           hover:border-green-500 hover:bg-green-500/10 transition-all duration-300 
@@ -92,7 +95,7 @@
                     </svg>
                 </a>
                 
-                <a href="https://www.instagram.com/pointofmadnessband/" target="_blank"
+                <a href="{{ \App\Models\Linktree::url('instagram', $spotifyLink) }}" target="_blank"
                    class="group w-12 h-12 bg-gradient-to-br from-pink-500/20 to-purple-600/20 
                           border border-pink-500/30 rounded-full flex items-center justify-center 
                           hover:border-pink-500 hover:bg-pink-500/10 transition-all duration-300 
@@ -102,7 +105,7 @@
                     </svg>
                 </a>
                 
-                <a href="https://www.tiktok.com/@point.of.madness" target="_blank"
+                <a href="{{ \App\Models\Linktree::url('tiktok', $spotifyLink) }}" target="_blank"
                    class="group w-12 h-12 bg-gradient-to-br from-gray-500/20 to-gray-600/20 
                           border border-gray-500/30 rounded-full flex items-center justify-center 
                           hover:border-gray-500 hover:bg-gray-500/10 transition-all duration-300 
@@ -112,7 +115,7 @@
                     </svg>
                 </a>
                 
-                <a href="#" class="group w-12 h-12 bg-gradient-to-br from-blue-500/20 to-blue-600/20 
+                <a href="{{ \App\Models\Linktree::url('twitter', $spotifyLink) }}" target="_blank" class="group w-12 h-12 bg-gradient-to-br from-blue-500/20 to-blue-600/20 
                           border border-blue-500/30 rounded-full flex items-center justify-center 
                           hover:border-blue-500 hover:bg-blue-500/10 transition-all duration-300 
                           transform hover:scale-110">
@@ -121,7 +124,7 @@
                     </svg>
                 </a>
                 
-                <a href="#" class="group w-12 h-12 bg-gradient-to-br from-red-500/20 to-red-600/20 
+                <a href="{{ \App\Models\Linktree::url('youtube', $spotifyLink) }}" target="_blank" class="group w-12 h-12 bg-gradient-to-br from-red-500/20 to-red-600/20 
                           border border-red-500/30 rounded-full flex items-center justify-center 
                           hover:border-red-500 hover:bg-red-500/10 transition-all duration-300 
                           transform hover:scale-110">

--- a/resources/views/components/modal/linktree/modal.blade.php
+++ b/resources/views/components/modal/linktree/modal.blade.php
@@ -26,7 +26,7 @@
                     Social Media
                 </h3>
                 <div class="grid gap-3">
-                    <a href="https://instagram.com/pointofmadnessband" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('instagram', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-pink-600 to-purple-600 
                               rounded-xl hover:from-pink-500 hover:to-purple-500 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -39,7 +39,7 @@
                         </div>
                     </a>
 
-                    <a href="https://www.tiktok.com/@point.of.madness" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('tiktok', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-black to-gray-800 
                               rounded-xl hover:from-gray-800 hover:to-gray-700 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -63,7 +63,7 @@
                     Music Streaming
                 </h3>
                 <div class="grid gap-3">
-                    <a href="https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('spotify', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-green-600 to-green-500 
                               rounded-xl hover:from-green-500 hover:to-green-400 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -76,7 +76,7 @@
                         </div>
                     </a>
 
-                    <a href="https://music.amazon.com/artists/B0CZV1WG82/point-of-madness" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('amazon_music', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-orange-600 to-yellow-500 
                               rounded-xl hover:from-orange-500 hover:to-yellow-400 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -89,7 +89,7 @@
                         </div>
                     </a>
 
-                    <a href="https://www.deezer.com/us/artist/260843331" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('deezer', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-purple-600 to-pink-500 
                               rounded-xl hover:from-purple-500 hover:to-pink-400 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -102,7 +102,7 @@
                         </div>
                     </a>
 
-                    <a href="https://tidal.com/artist/46872152" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('tidal', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-blue-900 to-cyan-700 
                               rounded-xl hover:from-blue-800 hover:to-cyan-600 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -115,7 +115,7 @@
                         </div>
                     </a>
 
-                    <a href="https://open.qobuz.com/artist/22007984" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('qobuz', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-indigo-700 to-purple-700 
                               rounded-xl hover:from-indigo-600 hover:to-purple-600 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -128,7 +128,7 @@
                         </div>
                     </a>
 
-                    <a href="https://www.youtube.com/@PointofMadness" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('youtube', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-red-600 to-red-500 
                               rounded-xl hover:from-red-500 hover:to-red-400 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -141,7 +141,7 @@
                         </div>
                     </a>
 
-                    <a href="https://music.youtube.com/channel/UC3byFEMycsebbNGxeFhx6CQ" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('youtube_music', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-red-800 to-orange-600 
                               rounded-xl hover:from-red-700 hover:to-orange-500 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg">
@@ -166,7 +166,7 @@
                 </h3>
                 <div class="grid gap-3">
 
-                    <a href="https://www.youtube.com/watch?v=HGcrZPMlOrw" target="_blank" 
+                    <a href="{{ \App\Models\Linktree::url('toxic_music_video', '#') }}" target="_blank" 
                        class="flex items-center gap-4 p-4 bg-gradient-to-r from-gray-700 to-gray-600 
                               rounded-xl hover:from-gray-600 hover:to-gray-500 transition-all duration-300 
                               transform hover:scale-[1.02] hover:shadow-lg border-2 border-red-500/30">

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -119,7 +119,7 @@
                             </h3>
                             
                             <div class="space-y-4 mb-6">
-                                <a href="https://www.instagram.com/pointofmadnessband/" target="_blank"
+                                <a href="{{ \App\Models\Linktree::url('instagram', '#') }}" target="_blank"
                                    class="flex items-center gap-4 p-4 bg-gray-700/30 rounded-xl hover:bg-gray-700/50 transition-all duration-300 group">
                                     <div class="w-10 h-10 bg-gradient-to-br from-pink-500 to-purple-600 rounded-lg flex items-center justify-center">
                                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -132,7 +132,7 @@
                                     </div>
                                 </a>
                                 
-                                <a href="https://www.tiktok.com/@point.of.madness" target="_blank"
+                                <a href="{{ \App\Models\Linktree::url('tiktok', '#') }}" target="_blank"
                                    class="flex items-center gap-4 p-4 bg-gray-700/30 rounded-xl hover:bg-gray-700/50 transition-all duration-300 group">
                                     <div class="w-10 h-10 bg-gradient-to-br from-gray-500 to-gray-600 rounded-lg flex items-center justify-center">
                                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -145,7 +145,7 @@
                                     </div>
                                 </a>
                                 
-                                <a href="https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi" target="_blank"
+                                <a href="{{ \App\Models\Linktree::url('spotify', '#') }}" target="_blank"
                                    class="flex items-center gap-4 p-4 bg-gray-700/30 rounded-xl hover:bg-gray-700/50 transition-all duration-300 group">
                                     <div class="w-10 h-10 bg-gradient-to-br from-green-500 to-green-600 rounded-lg flex items-center justify-center">
                                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -137,7 +137,7 @@
                         
                         <!-- Social Links -->
                         <div class="flex justify-center gap-4">
-                            <a href="https://www.instagram.com/pointofmadnessband/" target="_blank"
+                            <a href="{{ \App\Models\Linktree::url('instagram', '#') }}" target="_blank"
                                class="bg-gradient-to-r from-pink-600 to-purple-600 text-white px-6 py-3 rounded-full 
                                       font-semibold hover:from-pink-500 hover:to-purple-500 transition-all duration-300 
                                       transform hover:scale-105 hover:shadow-lg hover:shadow-pink-500/30 flex items-center gap-2">
@@ -147,7 +147,7 @@
                                 Follow on Instagram
                             </a>
                             
-                            <a href="https://www.tiktok.com/@point.of.madness" target="_blank"
+                            <a href="{{ \App\Models\Linktree::url('tiktok', '#') }}" target="_blank"
                                class="bg-gradient-to-r from-gray-600 to-gray-700 text-white px-6 py-3 rounded-full 
                                       font-semibold hover:from-gray-500 hover:to-gray-600 transition-all duration-300 
                                       transform hover:scale-105 hover:shadow-lg hover:shadow-gray-500/30 flex items-center gap-2">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -42,17 +42,17 @@
 
                 <!-- Social Icons -->
                 <div class="hidden sm:flex items-center space-x-3">
-                    <a href="https://www.instagram.com/pointofmadnessband/" target="_blank"
-                       class="w-10 h-10 bg-gradient-to-br from-pink-500/20 to-purple-600/20 border border-pink-500/30 
-                              rounded-full flex items-center justify-center hover:border-pink-500 hover:bg-pink-500/10 
+                    <a href="{{ \App\Models\Linktree::url('instagram', '#') }}" target="_blank"
+                       class="w-10 h-10 bg-gradient-to-br from-pink-500/20 to-purple-600/20 border border-pink-500/30
+                              rounded-full flex items-center justify-center hover:border-pink-500 hover:bg-pink-500/10
                               transition-all duration-300 transform hover:scale-110">
                         <svg class="w-5 h-5 text-pink-400" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
                         </svg>
                     </a>
-                    <a href="https://open.spotify.com/artist/1YhRX1mRz6rzQofSyzlszi" target="_blank"
-                       class="w-10 h-10 bg-gradient-to-br from-green-500/20 to-green-600/20 border border-green-500/30 
-                              rounded-full flex items-center justify-center hover:border-green-500 hover:bg-green-500/10 
+                    <a href="{{ \App\Models\Linktree::url('spotify', '#') }}" target="_blank"
+                       class="w-10 h-10 bg-gradient-to-br from-green-500/20 to-green-600/20 border border-green-500/30
+                              rounded-full flex items-center justify-center hover:border-green-500 hover:bg-green-500/10
                               transition-all duration-300 transform hover:scale-110">
                         <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.42 1.56-.299.421-1.02.599-1.559.3z"/>


### PR DESCRIPTION
## Summary
- add a Linktree Eloquent model, migration, and seeder so external URLs are driven by the linktree dataset
- update navigation, hero, music, contact, events, footer, and linktree modal views to resolve their external links through the Linktree model with Spotify fallbacks

## Testing
- `php artisan test` *(fails: vendor dependencies missing and composer install requires a GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68d155b4503c8333878baeb3a23ec9b5